### PR TITLE
Add a .sync option to Loggers

### DIFF
--- a/lib/manageiq/loggers/base.rb
+++ b/lib/manageiq/loggers/base.rb
@@ -21,6 +21,9 @@ module ManageIQ
         # version of Rails.
         self.formatter = Formatter.new
 
+        @sync = false if @sync.nil?
+        @logdev.dev.sync = sync
+
         # Allow for thread safe Logger level changes, similar to functionalities
         # provided by ActiveSupport::LoggerThreadSafeLevel
         @write_lock   = Mutex.new
@@ -40,6 +43,12 @@ module ManageIQ
       end
 
       attr_reader :logdev # Expose logdev
+      attr_reader :sync   # Control IO device buffering
+
+      def sync=(sync)
+        @sync = sync
+        @logdev.dev.sync = sync if @logdev
+      end
 
       def logdev=(logdev)
         if @logdev
@@ -52,6 +61,9 @@ module ManageIQ
         end
 
         @logdev = LogDevice.new(logdev, :shift_age => shift_age, :shift_size => shift_size)
+        @logdev.dev.sync = sync
+
+        @logdev
       end
 
       def log_backtrace(err, level = :error)

--- a/lib/manageiq/loggers/container.rb
+++ b/lib/manageiq/loggers/container.rb
@@ -2,6 +2,7 @@ module ManageIQ
   module Loggers
     class Container < Base
       def initialize(logdev = STDOUT, *args)
+        @sync = true
         super
         self.level = DEBUG
         self.formatter = Formatter.new


### PR DESCRIPTION
Add an option to ManageIQ::Loggers to control the underlying logdev
device buffering and default container logger to true.